### PR TITLE
Fix f-string quote syntax errors in sampling and training workers

### DIFF
--- a/sampling_worker.py
+++ b/sampling_worker.py
@@ -265,8 +265,8 @@ def main():
         config = yaml.safe_load(f)
     
     print("=== GRPO采样进程 ===")
-    print(f"GPU ID: {config["gpu"]["sampling_gpu"]}")
-    print(f"数据端口: {config["communication"]["data_port"]}")
+    print(f"GPU ID: {config['gpu']['sampling_gpu']}")
+    print(f"数据端口: {config['communication']['data_port']}")
 
     # 创建并运行采样进程
     worker = SamplingWorker(config)

--- a/training_worker.py
+++ b/training_worker.py
@@ -436,7 +436,7 @@ def main():
     worker = TrainingWorker(config=config)
 
     print("=== GRPO训练进程 ===")
-    print(f"数据端口: {config["communication"]["data_port"]}")
+    print(f"数据端口: {config['communication']['data_port']}")
     print(f"DeepSpeed: 启用")
     print(f"当前进程: Rank {worker.rank}/{worker.world_size-1}, 主进程: {worker.is_main_process}")
 


### PR DESCRIPTION
### Summary
Fix syntax errors caused by incorrect quote usage inside f-strings.

### Details
Replaced inner double quotes with single quotes when accessing config fields, preventing Python syntax errors during execution.

### Testing
Verified locally that both workers start without syntax errors.
